### PR TITLE
Fix appointment queries

### DIFF
--- a/.github/workflows/pr.workflow.yml
+++ b/.github/workflows/pr.workflow.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
       - run: npm install

--- a/.github/workflows/pr.workflow.yml
+++ b/.github/workflows/pr.workflow.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v2
         with:
           node-version: '14'
       - run: npm install

--- a/src/appointments/graph.ts
+++ b/src/appointments/graph.ts
@@ -21,7 +21,6 @@ const fragments = gql`
     startAt
     startTimeOffset
     totalDuration
-    baseAppointmentServiceId
   }
 
   fragment AppointmentProperties on Appointment {

--- a/src/appointments/graph.ts
+++ b/src/appointments/graph.ts
@@ -20,7 +20,7 @@ const fragments = gql`
     staffRequested
     startAt
     startTimeOffset
-    totalDuration
+    totalDuration2
   }
 
   fragment AppointmentProperties on Appointment {

--- a/src/appointments/graph.ts
+++ b/src/appointments/graph.ts
@@ -21,6 +21,7 @@ const fragments = gql`
     startAt
     startTimeOffset
     totalDuration
+    baseAppointmentServiceId
   }
 
   fragment AppointmentProperties on Appointment {


### PR DESCRIPTION
The baseAppointmentServiceId was added to the appointmentServices field but the PlatformClient which book-sdk binds to doesn't contain it (it's only available in the PlatformAdmin schema). This meant that Appointment queries were failing with errors because they requested the field which doesn't exist.