### PR TITLE
[Api 1216] fix appointments query

### DIFF
--- a/src/appointments/graph.ts
+++ b/src/appointments/graph.ts
@@ -21,7 +21,6 @@ const fragments = gql`
     startAt
     startTimeOffset
     totalDuration
-    baseAppointmentServiceId
   }
 
   fragment AppointmentProperties on Appointment {


### PR DESCRIPTION
The baseAppointmentServiceId was added to the appointmentServices field but the PlatformClient which book-sdk binds to doesn't contain it (it's only available in the PlatformAdmin schema). This meant that Appointment queries were failing with errors because they requested the field which doesn't exist.