### PR TITLE
[API-644] Add optional zip code to checkout cart

### DIFF
--- a/src/cart.ts
+++ b/src/cart.ts
@@ -334,6 +334,7 @@ class Cart extends Node<Graph.Cart> {
           cvv: string;
           exp_month: number;
           exp_year: number;
+          address_postal_code?: string;
         };
       }
       | { token: string },
@@ -364,6 +365,7 @@ class Cart extends Node<Graph.Cart> {
           cvv: string;
           exp_month: number;
           exp_year: number;
+          address_postal_code?: string;
         };
       }
       | { token: string }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -17,7 +17,7 @@ import { Location } from "../src/locations";
 import { createHmac } from "crypto";
 
 const businessId = "63b60ecb-6d1e-4bb6-87ad-3cb52ffe09b4";
-const apiKey = process.env.SANDBOX_API_KEY;
+const apiKey = process.env.SANDBOX_API_KEY!;
 const anon = new Blvd(apiKey, businessId);
 
 describe("appointments", () => {


### PR DESCRIPTION
Facilitates https://github.com/Boulevard/abundant-booking-flow/pull/73

Adds `address_postal_code` as an optional property on the `addCardPaymentMethod` mutation. Vault is already familiar with the property and will use it during processing if available.
