### PR TITLE
[PAY-1787] Require postal code

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ await cart.addCardPaymentMethod({
     number: "4242424242424242",
     cvv: "111",
     exp_month: 1,
-    exp_year: 2025
+    exp_year: 2025,
+    address_postal_code: "90210"
   }
 });
 

--- a/src/cart.ts
+++ b/src/cart.ts
@@ -334,7 +334,7 @@ class Cart extends Node<Graph.Cart> {
           cvv: string;
           exp_month: number;
           exp_year: number;
-          address_postal_code?: string;
+          address_postal_code: string;
         };
       }
       | { token: string },

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -207,7 +207,8 @@ describe("carts", () => {
         number: "4242424242424242",
         cvv: "111",
         exp_month: 1,
-        exp_year: 2025
+        exp_year: 2025,
+        address_postal_code: "90210"
       }
     });
 


### PR DESCRIPTION
**Summary:**

This PR requires postal code as part of the ongoing AVS requirement initiative.

This simply makes `address_postal_code` required instead of optional for our API consumers.