### PR TITLE
v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boulevard/blvd-book-sdk",
-  "version": "1.0.38",
+  "version": "2.0.0",
   "description": "A JS client for the Boulevard API",
   "main": "lib/blvd.js",
   "typings": "lib/blvd.js",


### PR DESCRIPTION
Since this change is backward incompatible (mainly the zip code requirement) and will break client's installations without changes on their part, this is considered a major version upgrade