### PR TITLE
[CXP-1822] fix invalid fragments and `getAvailablePaymentMethods`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boulevard/blvd-book-sdk",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A JS client for the Boulevard API",
   "main": "lib/blvd.js",
   "typings": "lib/blvd.js",

--- a/src/cart.ts
+++ b/src/cart.ts
@@ -740,7 +740,8 @@ class Cart extends Node<Graph.Cart> {
    */
   async getAvailablePaymentMethods(): Promise<Array<CartItemPaymentMethod>> {
     const response = await this.platformClient.request(
-      graph.availablePaymentMethodsQuery
+      graph.availablePaymentMethodsQuery,
+      { id: this.id }
     );
 
     return response.cart.availablePaymentMethods.map(

--- a/src/carts/graph.ts
+++ b/src/carts/graph.ts
@@ -335,7 +335,7 @@ export const availableBookableItemStaffVariantsQuery = gql`
 `;
 
 export const availablePaymentMethodsQuery = gql`
-  ${fragments}
+  ${fragments.paymentMethod}
   query Cart($id: ID!) {
     cart(id: $id) {
       availablePaymentMethods {
@@ -346,7 +346,7 @@ export const availablePaymentMethodsQuery = gql`
 `;
 
 export const bookableStaffVariantsQuery = gql`
-  ${fragments}
+  ${staffFragments}
   query CartBookableStaffVariants($id: ID!, $itemId: ID!, bookableTimeId: ID!) {
     cartBookableStaffVariants(id: $id, itemId: $itemId, bookableTimeId: $bookableTimeId) {
       id


### PR DESCRIPTION
- correct fragments are now used in `availablePaymentMethodsQuery` and `bookableStaffVariantsQuery`
- `getAvailablePaymentMethods` now includes the cart id in the request
- resolves #25 