### PR TITLE
patching flaky test

### DIFF
--- a/.github/workflows/release.workflow.yml
+++ b/.github/workflows/release.workflow.yml
@@ -17,6 +17,7 @@ jobs:
         uses: ./.github/actions/install-dependencies
       - run: npm test
         env:
+          TZ: "America/Los_Angeles"
           SANDBOX_API_KEY: ${{ secrets.SANDBOX_API_KEY }}
 
       - uses: "marvinpinto/action-automatic-releases@latest"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boulevard/blvd-book-sdk",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A JS client for the Boulevard API",
   "main": "lib/blvd.js",
   "typings": "lib/blvd.js",

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -64,7 +64,7 @@ describe("carts", () => {
   test("create and set location", async () => {
     const locations = await anon.locations.list();
     const cart = await anon.carts.create();
-    
+
     expect(cart).toBeInstanceOf(Cart);
     let categories = await cart.getAvailableCategories();
     const item = categories[0].availableItems[0] as CartAvailableBookableItem;
@@ -188,7 +188,10 @@ describe("carts", () => {
     cart = await cart.addBookableItem(service as CartAvailableBookableItem);
 
     const dates = await cart.getBookableDates();
-    const date = dates[0];
+    // kind of a hack to protect against flaky timezone boundary behaviour
+    // selects the next day after today, just in case today is too late in the day
+    // we should always be able to use tomorrow, but just to be safe fallback on today
+    const date = dates[1] || dates[0];
 
     const times = await cart.getBookableTimes(date);
     const time = times[0];


### PR DESCRIPTION
- one of the integration tests that relies on precision scheduling can sometimes run into problems depending on the time of day
- fix is to use the following day instead of today when testing cart bookable times