### PR TITLE
updating npmrc provisioning for public registry

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -18,5 +18,5 @@ runs:
     - name: Install node modules
       shell: bash
       run: |
-        echo "//npm.pkg.github.com/:_authToken=${{ inputs.github-token }}" >> .npmrc
+        echo "registry=https://registry.npmjs.org" >> .npmrc
         yarn install --frozen-lockfile


### PR DESCRIPTION
- updates the `install-dependencies` action to provision the `.npmrc` file for the public npmjs registry
- related to https://github.com/Boulevard/book-sdk/pull/23