### PR TITLE
updating github workflows for npm publish

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -14,10 +14,12 @@ runs:
       with:
         path: "**/node_modules"
         key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-    - name: Install node modules
+    - name: Configure npmrc
       shell: bash
       run: |
         echo "//registry.npmjs.org/:_authToken=${{ inputs.npm-token }}" >> .npmrc
         echo "registry=https://registry.npmjs.org" >> .npmrc
         echo "always-auth=true" >> .npmrc
-        yarn install --frozen-lockfile
+    - name: Install node modules
+      shell: bash
+      run: yarn install --frozen-lockfile

--- a/.github/workflows/pr.workflow.yml
+++ b/.github/workflows/pr.workflow.yml
@@ -16,4 +16,5 @@ jobs:
         uses: ./.github/actions/install-dependencies
       - run: npm test
         env:
+          TZ: "America/Los_Angeles"
           SANDBOX_API_KEY: ${{ secrets.SANDBOX_API_KEY }}

--- a/.github/workflows/release.workflow.yml
+++ b/.github/workflows/release.workflow.yml
@@ -21,13 +21,11 @@ jobs:
         env:
           TZ: "America/Los_Angeles"
           SANDBOX_API_KEY: ${{ secrets.SANDBOX_API_KEY }}
-
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false
-
       - run: npm run build
+      # if publish is failing, the current token has likely expired and a new token needs to be created
+      # create a new granular token with read/write access to expire in 1 year at https://www.npmjs.com/settings/blvd-it/tokens/
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boulevard/blvd-book-sdk",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "A JS client for the Boulevard API",
   "main": "lib/blvd.js",
   "typings": "lib/blvd.js",


### PR DESCRIPTION
- splitting up dependency action into 2 steps: configure npmrc, then install dependencies
- adding `TZ` to `npm test` step
- removing `NODE_AUTH_TOKEN` from release workflow (token is now set in the dependency action)
- adding some notes on how to rotate the npm token