### PR TITLE
verify updated npm release token

### DIFF
--- a/.github/workflows/pr.workflow.yml
+++ b/.github/workflows/pr.workflow.yml
@@ -14,7 +14,13 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
+        with:
+          npm-token: ${{ secrets.NPM_TOKEN }}
       - run: npm test
         env:
           TZ: "America/Los_Angeles"
           SANDBOX_API_KEY: ${{ secrets.SANDBOX_API_KEY }}
+      # if whoami is failing, the current token has likely expired and a new token needs to be created
+      # create a new granular token with read/write access to expire in 1 year at https://www.npmjs.com/settings/blvd-it/tokens/
+      - name: Verify npm token auth
+        run: npm whoami > /dev/null

--- a/.github/workflows/release.workflow.yml
+++ b/.github/workflows/release.workflow.yml
@@ -26,6 +26,4 @@ jobs:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false
       - run: npm run build
-      # if publish is failing, the current token has likely expired and a new token needs to be created
-      # create a new granular token with read/write access to expire in 1 year at https://www.npmjs.com/settings/blvd-it/tokens/
       - run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boulevard/blvd-book-sdk",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "A JS client for the Boulevard API",
   "main": "lib/blvd.js",
   "typings": "lib/blvd.js",


### PR DESCRIPTION
- performs an npm token check in CI (guarantees auth, but does not guarantee ability to deploy)