### PR TITLE
[CXP-2643] adding support for dynamic SDK version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lib*
 .env
 schema.json
 .DS_Store
+.npmrc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boulevard/blvd-book-sdk",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "A JS client for the Boulevard API",
   "main": "lib/blvd.js",
   "typings": "lib/blvd.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 // rollup.config.js
 import typescript from "@rollup/plugin-typescript";
 import common from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 
 export default [
@@ -12,7 +13,7 @@ export default [
       format: "es",
       name: "blvd-book"
     },
-    plugins: [typescript()]
+    plugins: [typescript(), json()]
   },
   {
     input: "src/blvd.ts",
@@ -22,6 +23,6 @@ export default [
       format: "umd",
       name: "boulevard"
     },
-    plugins: [nodeResolve({ browser: true }), common(), typescript()]
+    plugins: [nodeResolve({ browser: true }), common(), typescript(), json()]
   }
 ];

--- a/src/blvd.ts
+++ b/src/blvd.ts
@@ -1,7 +1,7 @@
 import { Appointments } from "./appointments";
 import { Businesses } from "./businesses";
 import { Carts } from "./carts";
-import { PlatformClient, PlatformTarget } from "./platformClient";
+import { PlatformClient, PlatformTarget, SDK_VERSION } from "./platformClient";
 import { Clients } from "./clients";
 import { Locations } from "./locations";
 import { Maybe, Scalars } from "./graph";
@@ -33,4 +33,4 @@ class Blvd {
   }
 }
 
-export { Blvd, PlatformTarget, Maybe, Scalars };
+export { Blvd, PlatformTarget, Maybe, Scalars, SDK_VERSION };

--- a/src/platformClient.test.ts
+++ b/src/platformClient.test.ts
@@ -1,5 +1,6 @@
 import fetch from "cross-fetch";
 import { PlatformClient, PlatformTarget } from "./platformClient";
+import { version } from "./../package.json";
 
 jest.mock("cross-fetch", mockFetch({}));
 
@@ -15,7 +16,7 @@ describe("testing api", () => {
       {
         body: '{"query":""}',
         headers: {
-          "Book-SDK-Version": "1.0.21",
+          "Book-SDK-Version": version,
           Authorization:
             "Basic MTk3ZjNlYWMtZjkwZC00MmIzLTgwZWQtZTNhNjgyODg2NDdiOg==",
           "Content-Type": "application/json"
@@ -40,7 +41,7 @@ describe("testing api", () => {
           Authorization:
             "Basic YTcyMjdhZDAtOTA0Mi00ZThkLTkzNDktMzMyYWI2NTQ0MDI3Og==",
           "Content-Type": "application/json",
-          "Book-SDK-Version": "1.0.21"
+          "Book-SDK-Version": version
         },
         method: "POST"
       }
@@ -64,7 +65,7 @@ describe("testing api", () => {
       {
         body: '{"query":""}',
         headers: {
-          "Book-SDK-Version": "1.0.21",
+          "Book-SDK-Version": version,
           Authorization:
             "Basic MjY1ZTUzNjUtYjc0Mi00MDlmLTk4ZWYtZDg5MGIzZWZkZTcwOg==",
           "Content-Type": "application/json"

--- a/src/platformClient.ts
+++ b/src/platformClient.ts
@@ -2,9 +2,9 @@ import { GraphQLClient } from "graphql-request";
 import { RequestDocument, Variables } from "graphql-request/dist/types";
 import { getSdk, Sdk } from "./graph";
 import { inspect } from "util";
-// import { version } from './../package.json';
+import { version } from "./../package.json";
 
-const version = "1.0.21";
+export const SDK_VERSION = version;
 
 const btoa = string => {
   const buffer = Buffer.from(string.toString(), "binary");
@@ -100,7 +100,7 @@ class PlatformClient {
   private headers(): Record<"Authorization" | "Book-SDK-Version", string> {
     return {
       Authorization: `Basic ${this.token()}`,
-      "Book-SDK-Version": version
+      "Book-SDK-Version": SDK_VERSION
     };
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "outDir": "lib",
     "jsx": "react",
     "lib": ["es2016", "dom", "es5"],
-    "rootDir": "src",
+    "baseUrl": "./src",
+    "rootDir": "."
   },
   "files": ["src/blvd.ts"],
   "compileOnSave": false,


### PR DESCRIPTION
Adds support for reporting the correct SDK version

- Our SDK version header was locked at `1.0.21` via a static const
- Now fetching the version from the `package.json` file
- this requires adding `@rollup/plugin-json` to the plugins
- this also requires patching the `tsconfig.json` to support importing files at the root
- We will now also export the `SDK_VERSION` const at the API surface
- finally, adding `.npmrc` to the `.gitignore` file so we don't accidentally commit a local file
- https://blvd.atlassian.net/browse/CXP-2643
- we can [see the version in DD](https://app.datadoghq.com/logs?query=service:sched-prod%20@blvd_metadata.sdk_version:*%20-@blvd_metadata.sdk_version:%22%22&agg_m=count&agg_m_source=base&agg_q=@blvd_metadata.sdk_version&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=@blvd_metadata.source_id,@blvd_metadata.destination_id&messageDisplay=inline&storage=hot&stream_sort=time,desc&top_n=10&top_o=top&viz=timeseries&x_missing=true&from_ts=1758586566445&to_ts=1758587466445&live=true)